### PR TITLE
chore: update .gitignore and pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # compiled output
 /dist
-/node_modules
+node_modules
 
 # Logs
 logs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-lint-staged
+npx lint-staged


### PR DESCRIPTION
- Modified .gitignore to ensure node_modules is ignored correctly.
- Updated pre-commit hook to use 'npx lint-staged' for better compatibility and execution.